### PR TITLE
Hotfix/readme/in progress recipes shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,7 +730,7 @@ As telas sofrem variações dependendo do tipo da receita (se é comida ou bebid
 - Verifica se ao marcar clicar em um checkbox de um ingrediente de uma comida, o nome aparecerá riscado, mostrando que esse passo foi finalizado;
 - Verifica se ao marcar clicar em um checkbox de um ingrediente de uma bebida, o nome aparecerá riscado, mostrando que esse passo foi finalizado.
 
-### 51 - O estado do progresso deve ser mantido caso a pessoa atualize a pagina ou volte para a mesma receita. O progresso das receitas devem ser salvos em `localStorage` na chave` inProgressRecipes` no formato conforme especificado na seção [`localStorage`](#localStorage);
+### 51 - O estado do progresso deve ser mantido caso a pessoa atualize a pagina ou volte para a mesma receita. O progresso das receitas devem ser salvos em `localStorage` na chave` inProgressRecipes` no formato especificado na seção [`localStorage`](#localStorage);
 
 ##### As seguintes verificações serão feitas:
 

--- a/README.md
+++ b/README.md
@@ -343,13 +343,19 @@ No `localStorage` do navegador:
 
 * a chave `inProgressRecipes` deve conter a seguinte estrutura:
 ```
-{
-    id-da-receita: [lista-de-ingredientes-utilizados],
-    ...
-}
+[{
+    cocktails: {
+        id-da-bebida: [lista-de-ingredientes-utilizados],
+        ...
+    },
+    meals: {
+        id-da-comida: [lista-de-ingredientes-utilizados],
+        ...
+    }
+}]
 ```
 
-    **Observação:** Cada ID representa o ID de uma receita e cada item da lista de ingredientes da respectiva receita deve ser representado apenas pelo número do ingrediente no formato numérico.
+    **Observação:** `id-da-bebida` e `id-da-comida` representam o ID de uma bebida e comida, respectivamente, e cada item da lista de ingredientes da respectiva receita deve ser representado apenas pelo número do ingrediente no formato numérico.
 
 ### Ícones
 
@@ -724,7 +730,7 @@ As telas sofrem variações dependendo do tipo da receita (se é comida ou bebid
 - Verifica se ao marcar clicar em um checkbox de um ingrediente de uma comida, o nome aparecerá riscado, mostrando que esse passo foi finalizado;
 - Verifica se ao marcar clicar em um checkbox de um ingrediente de uma bebida, o nome aparecerá riscado, mostrando que esse passo foi finalizado.
 
-### 51 - O estado do progresso deve ser mantido caso a pessoa atualize a pagina ou volte para a mesma receita. O progresso das receitas devem ser salvos em `localStorage` na chave` inProgressRecipes` no formato `{ id-da-receita: [lista-de-ingredientes-utilizados], ... }`;
+### 51 - O estado do progresso deve ser mantido caso a pessoa atualize a pagina ou volte para a mesma receita. O progresso das receitas devem ser salvos em `localStorage` na chave` inProgressRecipes` no formato conforme especificado na seção [`localStorage`](#localStorage);
 
 ##### As seguintes verificações serão feitas:
 

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ No `localStorage` do navegador:
 
 * a chave `inProgressRecipes` deve conter a seguinte estrutura:
 ```
-[{
+{
     cocktails: {
         id-da-bebida: [lista-de-ingredientes-utilizados],
         ...
@@ -352,7 +352,7 @@ No `localStorage` do navegador:
         id-da-comida: [lista-de-ingredientes-utilizados],
         ...
     }
-}]
+}
 ```
 
     **Observação:** `id-da-bebida` e `id-da-comida` representam o ID de uma bebida e comida, respectivamente, e cada item da lista de ingredientes da respectiva receita deve ser representado apenas pelo número do ingrediente no formato numérico.

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ No `localStorage` do navegador:
 }]
 ```
 
-* a chave `inProggressRecipes` deve conter a seguinte estrutura:
+* a chave `inProgressRecipes` deve conter a seguinte estrutura:
 ```
 {
     id-da-receita: [lista-de-ingredientes-utilizados],

--- a/cypress/integration/recipe_detail_spec.js
+++ b/cypress/integration/recipe_detail_spec.js
@@ -291,9 +291,11 @@ describe('Caso a receita tenha sido iniciada mas não finalizada, o texto do bot
   it('Verifica botão de "Continuar Receita" na tela de detalhes de uma comida', () => {
     cy.visit('http://localhost:3000/comidas/52771', {
       onBeforeLoad(win) {
-        const inProgressRecipes = [{
-          52771: []
-        }];
+        const inProgressRecipes = {
+          meals: {
+            52771: [],
+          },
+        };
         localStorage.setItem('inProgressRecipes', JSON.stringify(inProgressRecipes));
         win.fetch = fetchMock;
       },
@@ -305,9 +307,11 @@ describe('Caso a receita tenha sido iniciada mas não finalizada, o texto do bot
   it('Verifica botão de "Continuar Receita" na tela de detalhes de uma bebida', () => {
     cy.visit('http://localhost:3000/bebidas/178319', {
       onBeforeLoad(win) {
-        const inProgressRecipes = [{
-          178319: []
-        }];
+        const inProgressRecipes = {
+          cocktails: {
+            178319: [],
+          },
+        };
         localStorage.setItem('inProgressRecipes', JSON.stringify(inProgressRecipes));
         win.fetch = fetchMock;
       },


### PR DESCRIPTION
- Este PR é para ajustar o readme com base no que foi alterado [neste PR](https://github.com/betrybe/sd-0x-recipes-app-n-tests/pull/4) no repositório template de testes
- Ajusta especificação do formato do objeto `inProgressRecipes` a ser salvo no local storage, de forma a possibilitar que comida e receita possuindo o mesmo ID consigam ser devidamente salvas no objeto.